### PR TITLE
Verify a transaction text fix

### DIFF
--- a/docs/03-transactions.md
+++ b/docs/03-transactions.md
@@ -57,7 +57,7 @@ Instructor Script:
 
 	Don't trust, verify.
 
-	There's a few steps to verifying a node. Let's go through them
+	There's a few steps to verifying a transaction. Let's go through them
 	together.
 
 


### PR DESCRIPTION
It looks like this was intended to say 'verifying a transaction' not 'verifying a node'.